### PR TITLE
Add repeat backward

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,12 @@ This plugin provides f/t/F/T mappings that can be customized by your setting.
 You can enable this plugin via following mappings.
 
 ```viml
-  nmap ; <Plug>(eft-repeat)
-  xmap ; <Plug>(eft-repeat)
-  omap ; <Plug>(eft-repeat)
+  nmap ; <Plug>(eft-repeat-next)
+  xmap ; <Plug>(eft-repeat-next)
+  omap ; <Plug>(eft-repeat-next)
+  nmap , <Plug>(eft-repeat-prev)
+  xmap , <Plug>(eft-repeat-prev)
+  omap , <Plug>(eft-repeat-prev)
 
   nmap f <Plug>(eft-f)
   xmap f <Plug>(eft-f)

--- a/autoload/eft.vim
+++ b/autoload/eft.vim
@@ -7,11 +7,13 @@ let s:Dir.Prev = 2
 "
 " eft#repeat
 "
-function! eft#repeat() abort
-  if !empty(s:state) && s:repeatable(s:state.dir, s:state.till, v:true)
-    call s:goto(v:true, s:state.dir, s:state.till)
+function! eft#repeat(dir, fallback) abort
+  let l:dir = a:dir == s:state.dir ? s:Dir.Next : s:Dir.Prev
+
+  if !empty(s:state) && s:repeatable(l:dir, s:state.till, v:true)
+    call s:goto(v:true, l:dir, s:state.till)
   else
-    normal! ;
+    execute 'normal! ' . a:fallback
   endif
 endfunction
 

--- a/doc/eft.txt
+++ b/doc/eft.txt
@@ -89,8 +89,12 @@ MAPPING                                                          *eft-mapping*
 
 >
   " If you prefer ; as repeat.
-  nmap ; <Plug>(eft-repeat)
-  xmap ; <Plug>(eft-repeat)
+  nmap ; <Plug>(eft-repeat-next)
+  xmap ; <Plug>(eft-repeat-next)
+  omap ; <Plug>(eft-repeat-next)
+  nmap , <Plug>(eft-repeat-prev)
+  xmap , <Plug>(eft-repeat-prev)
+  omap , <Plug>(eft-repeat-prev)
 
   nmap f <Plug>(eft-f)
   xmap f <Plug>(eft-f)

--- a/plugin/eft.vim
+++ b/plugin/eft.vim
@@ -52,9 +52,12 @@ function! s:highlight() abort
 endfunction
 call s:highlight()
 
-nnoremap <silent> <Plug>(eft-repeat) <Cmd>call eft#repeat()<CR>
-xnoremap <silent> <Plug>(eft-repeat) <Cmd>call eft#repeat()<CR>
-onoremap <silent> <Plug>(eft-repeat) <Cmd>call eft#repeat()<CR>
+nnoremap <silent> <Plug>(eft-repeat-next) <Cmd>call eft#repeat(1, ';')<CR>
+xnoremap <silent> <Plug>(eft-repeat-next) <Cmd>call eft#repeat(1, ';')<CR>
+onoremap <silent> <Plug>(eft-repeat-next) <Cmd>call eft#repeat(1, ';')<CR>
+nnoremap <silent> <Plug>(eft-repeat-prev) <Cmd>call eft#repeat(2, ',')<CR>
+xnoremap <silent> <Plug>(eft-repeat-prev) <Cmd>call eft#repeat(2, ',')<CR>
+onoremap <silent> <Plug>(eft-repeat-prev) <Cmd>call eft#repeat(2, ',')<CR>
 
 nnoremap <expr><silent> <Plug>(eft-f-repeatable) <SID>map('forward', v:false, v:true)
 nnoremap <expr><silent> <Plug>(eft-t-repeatable) <SID>map('forward', v:true, v:true)


### PR DESCRIPTION
The standard "f" move has the ability to go back with ",".
The map is not present in vim-eft, so I added it.