### PR TITLE
Fix: Highlight is not restored when colorscheme changed

### DIFF
--- a/autoload/eft.vim
+++ b/autoload/eft.vim
@@ -35,7 +35,7 @@ endfunction
 " eft#clear
 "
 function! eft#clear() abort
-  augroup eft
+  augroup eft_reset_action_queue
     autocmd!
   augroup END
   let s:state = {}
@@ -103,7 +103,7 @@ endfunction
 " s:reserve_reset
 "
 function! s:reserve_reset() abort
-  augroup eft
+  augroup eft_reset_action_queue
     autocmd!
   augroup END
   call feedkeys("\<Cmd>call eft#_reserve_reset()\<CR>", 'in')
@@ -114,7 +114,7 @@ endfunction
 "
 function! eft#_reserve_reset() abort
   let s:state.curpos = getcurpos()
-  augroup eft
+  augroup eft_reset_action_queue
     autocmd!
     autocmd CursorMoved <buffer> call eft#_reset()
   augroup END


### PR DESCRIPTION
plugin/eft.vim#L31-34

```vim
augroup eft
  autocmd!
  autocmd ColorScheme * call s:highlight()
augroup END
```

This autocmd will be removed by `eft#clear()`.

So highlight is not enabled after colorscheme changed.
