### PR TITLE
Fix error on zero-width line

### DIFF
--- a/autoload/eft.vim
+++ b/autoload/eft.vim
@@ -66,7 +66,7 @@ function! s:goto(repeat, dir, till) abort
   let l:line = getline(l:curpos[1])
   let l:col = l:curpos[2]
   let l:tilloff = a:till ? 1 : 0
-  let l:indices = a:dir ==# s:Dir.Next ? range(l:col + l:tilloff, strlen(l:line)) : range(l:col - (2 + l:tilloff), 0, -1)
+  let l:indices = a:dir ==# s:Dir.Next ? range(l:col + l:tilloff, strlen(l:line) + l:tilloff) : range(l:col - (2 + l:tilloff), 0, -1)
 
   let l:char = get(s:state, 'char', v:null)
   if !a:repeat


### PR DESCRIPTION
There seems to be no practical problem, but `eft-t` and `eft-T` will cause an error in zero-width line